### PR TITLE
significant rewrite of the code, removed serdes, solved timestamp bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 csv = "1"
 num-traits = "0.2.15"
-serde = { version = "1", features = ["derive"] }
 vcd = "0.6.1"
+regex = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,125 +1,101 @@
-#![feature(is_sorted)]
+//#![feature(is_sorted)]
 use csv;
-use serde::{self, Deserialize, Serialize};
-use std::{error::Error, fs::File, io::BufWriter, path::PathBuf};
-use vcd::{ self, Value, TimescaleUnit, SimulationCommand };
-use std::io;
+use std::{error::Error, fs::File, io::BufWriter, path::PathBuf, io};
+use vcd::{ self, TimescaleUnit, SimulationCommand };
+use regex::Regex;
 use num_traits::PrimInt;
 
-#[derive(Debug, Deserialize)]
-struct RigolCSV {
-    #[serde(rename = "Time(s)")]
-    timestamp: String, // TODO: This field can be missing :/
-    #[serde(rename = "D7-D0")]
-    d7_d0: String, // TODO: Unfortunately those fields are "user-flippable" in order from the scope, i.e: d0_d7 vs d7_d0
-    #[serde(rename = "D15-D8")]
-    d15_d8: String,
-}
-
-#[derive(Debug, Serialize, Clone, Copy)]
 struct RigolDataSeries {
     timestamp: f64,
     signals: u16,
 }
 
-struct Values {
-    inner: Vec<Value>
-}
-
-/// extremely over engineered bit iterator
-struct BitIter<I>(I, u32);
-impl<I: PrimInt> Iterator for BitIter<I> {
-    type Item = bool;
-    fn next(&mut self) -> Option<bool> {
-        (self.1 > 0).then(|| {
-            let bit = self.0 & I::one() == I::one();
-            self.1 -= 1;
-            self.0 = self.0 >> 1_usize;
-            bit
-        })
-    }
-}
-trait BitIterExt: PrimInt {
-    fn bit_iter(self) -> BitIter<Self> {
-        BitIter(self.reverse_bits(), Self::zero().leading_zeros())
-    }
-}
-impl<I: PrimInt> BitIterExt for I {}
-
-impl From<u16> for Values {
-    fn from(v: u16) -> Values {
-        let mut out_bits = vec![];
-        for bit in v.bit_iter() {
-            if bit {
-                out_bits.push(Value::V1);
-            } else {
-                out_bits.push(Value::V0);
-            }
-        }
-        Values { inner: out_bits }
-    }
-}
-
-fn analyse_timeseries(signals: Vec<RigolDataSeries>, _t0: f64, _tinc: f64) {
-    let mut timeseries = vec![];
-    for s in signals {
-        timeseries.push(s.timestamp);
-    }
-
-    // TODO: Compare precision/accuracy lost with t0/tinc vs real timestamp
-    assert!(timeseries.is_sorted());
-    // assert_eq!(timeseries.windows(2)
-    //             .map(|slice| (slice[0] - slice[1]).abs()), 0.1)
-}
-
-fn read_rigol_csv() -> Result<Vec<RigolDataSeries>, Box<dyn Error>> {
-    let mut rdr = csv::ReaderBuilder::new()
-        .has_headers(false)
-        .flexible(true) // ignore broken header
-        .from_reader(io::stdin());
+fn read_rigol_csv<R: io::Read>(io_reader: R) -> Result<Vec<RigolDataSeries>, Box<dyn Error>> {
+	
+    let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(io_reader);
 
     // TODO: Handle CSV when timestamps are in each row (enum/option)
     // Initial timestamp...
-    let header = rdr.headers()?.clone();
-    dbg!(&header);
-    let t0_header: Vec<&str> = header[3].split('=').collect();
-    let t0 = t0_header[1].trim_start().replace('s', "").parse::<f64>()?;
-    // ...and increments
-    let tinc_header: Vec<&str> = header[4].split('=').collect();
-    let tinc = tinc_header[1].trim_start().parse::<f64>()?;
-    println!("Initial timestamp {t0} with increments of {tinc} seconds");
+    
+    let t0;
+    let t_inc;
 
-    let mut _t_now: f64;
-    let mut t_csv: f64;
+	let mut i_csv = None;
+
+	let mut i_d7_d0 = None;
+	let mut i_d15_d8 = None;
+
+	let mut i_d0_d7 = None;
+	let mut i_d8_d15 = None;
+    {
+		let mut t0_option : Option<f64> = None; 
+		let mut t_inc_option: Option<f64> = None;
+		
+		for (pos, header) in rdr.headers()?.iter().enumerate() {
+			
+			let t0_capture = Regex::new(r"t0 = ([^s]*)s$").unwrap().captures(header);
+			if t0_capture.is_some() { t0_option = Some(t0_capture.unwrap()[1].parse::<f64>()?); continue; }
+			
+			let t_inc_capture = Regex::new(r"tInc = ([^s]*)").unwrap().captures(header);
+			if t_inc_capture.is_some() { t_inc_option = Some(t_inc_capture.unwrap()[1].parse::<f64>()?); continue; }
+			
+			match header {
+				""        =>  Ok(()),
+				"Time(s)" =>  Ok(i_csv = Some(pos)),
+				"D7-D0"   =>  Ok(i_d7_d0 = Some(pos)),
+				"D15-D8"  =>  Ok(i_d15_d8 = Some(pos)),
+				"D0-D7"   =>  Ok(i_d0_d7 = Some(pos)),
+				"D8-D15"  =>  Ok(i_d8_d15 = Some(pos)),
+				_ => Err("Unknown header {header}"),
+			}?
+		}
+		t0 = t0_option.unwrap();
+		t_inc = t_inc_option.unwrap();
+	}
+	
+    
+    println!("Initial timestamp {t0} with increments of {t_inc} seconds");
 
     let mut signals: Vec<RigolDataSeries> = vec![];
 
-    for row in rdr.deserialize().skip(1) {
-        let record: RigolCSV = row?;
-        // Compare t0+tinc vs timestamp divergence
-        _t_now = t0 + tinc;
-        t_csv = record.timestamp.parse::<f64>()?;
-        // Parse digital signal groups
-        let d_group_low = record.d7_d0.parse::<f64>()?;
-        let d_group_high = record.d15_d8.parse::<f64>()?;
+	let mut t_now = t0;
+    for row in rdr.records() {
+		
+		let r = row?;
 
-        // https://stackoverflow.com/questions/19507730/how-do-i-parse-a-string-to-a-list-of-floats-using-functional-style
-        // https://stackoverflow.com/a/50244328/457116
-        let d_all = ((d_group_high as u16) << 8) | d_group_low as u16;
-        signals.push(RigolDataSeries { timestamp:t_csv, signals: d_all });
-        //assert_eq!(t_now, t_csv);
-        //println!("{:b}", d_all);
+		t_now = t_now + t_inc;
+        let t_csv = r[i_csv.unwrap()].parse::<f64>()?;
+        
+        assert!( (t_now - t_csv).abs() < t_inc);
+                
+        let mut d_all : u16 = 0;
+        
+        if i_d7_d0.is_some() { d_all += r[i_d7_d0.unwrap()].parse::<f64>()? as u16; }
+        if i_d0_d7.is_some() { d_all += r[i_d0_d7.unwrap()].parse::<f64>()? as u16; }
+
+        if i_d15_d8.is_some() { d_all += ( r[i_d15_d8.unwrap()].parse::<f64>()? as u16) << 8; }
+        if i_d8_d15.is_some() { d_all += ( r[i_d8_d15.unwrap()].parse::<f64>()? as u16) << 8; }
+        
+        signals.push(RigolDataSeries { timestamp: t_csv, signals: d_all } );
     }
-
-    analyse_timeseries(signals.clone(), t0, tinc);
+	
+	println!("Signals read");
 
     Ok(signals)
 }
 
-fn write_vcd(f: PathBuf, mut sigs: Vec<RigolDataSeries>) -> Result<(), Box<dyn Error>> {
-    let buf = BufWriter::new(File::create(f)?);
-    let mut writer = vcd::Writer::new(buf);
+fn write_vcd<W: io::Write>(io_writer: &mut W, sigs: Vec<RigolDataSeries>) -> Result<(), Box<dyn Error>> {
 
+	fn vcd_vector_from_u16(d : u16) -> Vec<vcd::Value> {
+		
+		let mut out_bits = vec![];
+		for n in 0..16 { out_bits.push( if d&(1<<(15-n))==0 { vcd::Value::V0 } else { vcd::Value::V1 } ) }
+		return out_bits
+	}
+	
+	let mut writer = vcd::Writer::new(io_writer);
+
+	
     // Write the header
     writer.timescale(1, TimescaleUnit::US)?;
     writer.add_module("top")?;
@@ -127,30 +103,23 @@ fn write_vcd(f: PathBuf, mut sigs: Vec<RigolDataSeries>) -> Result<(), Box<dyn E
     writer.upscope()?;
     writer.enddefinitions()?;
   
-    let first = &sigs[0];
-    let first_value = &Values::from(sigs[0].signals).inner;
     // Write the initial values
     writer.begin(SimulationCommand::Dumpvars)?;
-    writer.change_vector(data, first_value)?;
+    writer.change_vector(data, &vcd_vector_from_u16(sigs[0].signals))?;
     writer.end()?;
   
-    let offset = (first.timestamp * 1000000000.0).abs() as u64;
-    sigs.dedup_by(|a, b| a.timestamp <= b.timestamp);
+    let offset = sigs[0].timestamp;
     // Write the data values
     for s in sigs {
       // TODO: Tweak that 10000000 with the defined timescale in the header
-      let cur_timestamp = (s.timestamp.abs() * 1000000000.0) as u64;
-      let timestamp  = offset - cur_timestamp;
-      let value = Values::from(s.signals).inner;
-
-      writer.timestamp(timestamp)?;
-      writer.change_vector(data, value.as_slice())?;
+      writer.timestamp(((s.timestamp-offset).abs() * 1000000000.0) as u64)?;
+      writer.change_vector(data,  &vcd_vector_from_u16(s.signals))?;
     }
     Ok(())
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let sigs = read_rigol_csv()?;
-    write_vcd(PathBuf::from("data/test.vcd"), sigs)?;
+    let sigs = read_rigol_csv(io::stdin())?;
+    write_vcd(&mut BufWriter::new(File::create(PathBuf::from("data/test.vcd"))?), sigs)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,23 +3,32 @@ use csv;
 use std::{error::Error, fs::File, io::BufWriter, path::PathBuf, io};
 use vcd::{ self, TimescaleUnit, SimulationCommand };
 use regex::Regex;
-use num_traits::PrimInt;
 
-struct RigolDataSeries {
-    timestamp: f64,
-    signals: u16,
+struct RigolTSData {
+	timestamp: f64,
+	data: u16
 }
 
-fn read_rigol_csv<R: io::Read>(io_reader: R) -> Result<Vec<RigolDataSeries>, Box<dyn Error>> {
+struct RigolCSVData {
+	
+	t0 : f64,
+    t_inc : f64,
+	signals: Vec<RigolTSData>
+}
+
+fn read_rigol_csv<R: io::Read>(io_reader: R) -> Result<RigolCSVData, Box<dyn Error>> {
 	
     let mut rdr = csv::ReaderBuilder::new().flexible(true).from_reader(io_reader);
 
     // TODO: Handle CSV when timestamps are in each row (enum/option)
     // Initial timestamp...
     
-    let t0;
-    let t_inc;
-
+    let mut rigol = RigolCSVData {
+		t0 : 0.0,
+		t_inc : 0.0,
+		signals : vec![]
+	};
+    
 	let mut i_csv = None;
 
 	let mut i_d7_d0 = None;
@@ -49,25 +58,27 @@ fn read_rigol_csv<R: io::Read>(io_reader: R) -> Result<Vec<RigolDataSeries>, Box
 				_ => Err("Unknown header {header}"),
 			}?
 		}
-		t0 = t0_option.unwrap();
-		t_inc = t_inc_option.unwrap();
+		rigol.t0 = t0_option.unwrap();
+		rigol.t_inc = t_inc_option.unwrap();
 	}
 	
     
-    println!("Initial timestamp {t0} with increments of {t_inc} seconds");
+    println!("Initial timestamp {} with increments of {} seconds", rigol.t0, rigol.t_inc);
 
-    let mut signals: Vec<RigolDataSeries> = vec![];
-
-	let mut t_now = t0;
-    for row in rdr.records() {
+	let mut async_count = 0;
+	
+    for (i, row) in rdr.records().enumerate() {
 		
 		let r = row?;
 
-		t_now = t_now + t_inc;
+		let t_now = rigol.t0 + ((i) as f64) * rigol.t_inc;
         let t_csv = r[i_csv.unwrap()].parse::<f64>()?;
         
-        assert!( (t_now - t_csv).abs() < t_inc);
-                
+        //println!("{} == {}", format!("{:+0.2e}", t_now), format!("{:+0.2e}", t_csv));
+        async_count = async_count + 1;
+		if format!("{:+0.4e}", t_now) == format!("{:+0.4e}", t_csv) { async_count = 0; }
+		assert!(async_count < 5);
+        
         let mut d_all : u16 = 0;
         
         if i_d7_d0.is_some() { d_all += r[i_d7_d0.unwrap()].parse::<f64>()? as u16; }
@@ -76,15 +87,15 @@ fn read_rigol_csv<R: io::Read>(io_reader: R) -> Result<Vec<RigolDataSeries>, Box
         if i_d15_d8.is_some() { d_all += ( r[i_d15_d8.unwrap()].parse::<f64>()? as u16) << 8; }
         if i_d8_d15.is_some() { d_all += ( r[i_d8_d15.unwrap()].parse::<f64>()? as u16) << 8; }
         
-        signals.push(RigolDataSeries { timestamp: t_csv, signals: d_all } );
+        rigol.signals.push(RigolTSData { timestamp: t_now, data: d_all } );
     }
 	
 	println!("Signals read");
 
-    Ok(signals)
+    Ok(rigol)
 }
 
-fn write_vcd<W: io::Write>(io_writer: &mut W, sigs: Vec<RigolDataSeries>) -> Result<(), Box<dyn Error>> {
+fn write_vcd<W: io::Write>(io_writer: &mut W, rigol: RigolCSVData) -> Result<(), Box<dyn Error>> {
 
 	fn vcd_vector_from_u16(d : u16) -> Vec<vcd::Value> {
 		
@@ -97,7 +108,7 @@ fn write_vcd<W: io::Write>(io_writer: &mut W, sigs: Vec<RigolDataSeries>) -> Res
 
 	
     // Write the header
-    writer.timescale(1, TimescaleUnit::US)?;
+    writer.timescale( (rigol.t_inc / 1e-12) as u32, TimescaleUnit::PS)?;
     writer.add_module("top")?;
     let data = writer.add_wire(16, "data")?;
     writer.upscope()?;
@@ -105,21 +116,21 @@ fn write_vcd<W: io::Write>(io_writer: &mut W, sigs: Vec<RigolDataSeries>) -> Res
   
     // Write the initial values
     writer.begin(SimulationCommand::Dumpvars)?;
-    writer.change_vector(data, &vcd_vector_from_u16(sigs[0].signals))?;
+    writer.change_vector(data, &vcd_vector_from_u16(rigol.signals[0].data))?;
     writer.end()?;
   
-    let offset = sigs[0].timestamp;
+    let offset = rigol.signals[0].timestamp;
     // Write the data values
-    for s in sigs {
+    for s in rigol.signals {
       // TODO: Tweak that 10000000 with the defined timescale in the header
       writer.timestamp(((s.timestamp-offset).abs() * 1000000000.0) as u64)?;
-      writer.change_vector(data,  &vcd_vector_from_u16(s.signals))?;
+      writer.change_vector(data,  &vcd_vector_from_u16(s.data))?;
     }
     Ok(())
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let sigs = read_rigol_csv(io::stdin())?;
-    write_vcd(&mut BufWriter::new(File::create(PathBuf::from("data/test.vcd"))?), sigs)?;
+    let rigol_data = read_rigol_csv(io::stdin())?;
+    write_vcd(&mut BufWriter::new(File::create(PathBuf::from("data/test.vcd"))?), rigol_data)?;
     Ok(())
 }


### PR DESCRIPTION
Significant rework of the code.

Removed serdes processing of the csv, which did not support the weird format from Rigol. 
Headers are captured using regex for additional safety, and flipable headers are supported (albeit the data is not altered).

Removed the overengineered iterator, which was meant to be able to traverse the bits in both directions. It should be simpler to just reverse the vector of values afterwards if needed.

Cleaned a little bit the writer by removing a few named variables that did not increase clarity (alternatively, their names could have been made more verbose). In the process, a bug was solved on the writer where .abs() was being used on a negative number, messing up timestamps.

A few checks to analyze the validity of Rigol timestamps have been superseeded by a single assert.

Significant possible improvements remain: 
- dealing with reverse bit fields in the csv (format or tests missing)
- error handling (what if source is missing, or there are no records)
- handling different timescales.